### PR TITLE
Fix crash on python3

### DIFF
--- a/mysql-workbench-plugin-doc-generating.py
+++ b/mysql-workbench-plugin-doc-generating.py
@@ -24,7 +24,7 @@ def documentation(diagram):
     mforms.Utilities.set_clipboard_text(text)
     mforms.App.get().set_status_text("Documentation generated into the clipboard. Paste it to your editor.")
 
-    print "Documentation is copied to the clipboard."
+    print("Documentation is copied to the clipboard.")
     return 0
 
 def writeTableDoc(table):


### PR DESCRIPTION
print is now a function, and not a statement anymore. Parenthesis added.